### PR TITLE
fix cargo test error when running rebar3 eunit

### DIFF
--- a/src/cargo_cmd.erl
+++ b/src/cargo_cmd.erl
@@ -49,7 +49,7 @@ run(Opts, Args) ->
 % Code derived from rebar3
 exec(Command, Path) ->
     OutputHandler =
-    fun (Line, Acc) when Line =/= "" ->
+    fun (<<"{", _/binary>> = Line, Acc) ->
             [jsx:decode(Line, [return_maps]) | Acc];
         (_, Acc) ->
             Acc


### PR DESCRIPTION
fix rebar3 eunit error when processing cargo test output bellow

```

running 1 test
test tests::it_works ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```